### PR TITLE
Allow changing default style

### DIFF
--- a/components/button.go
+++ b/components/button.go
@@ -33,8 +33,8 @@ func (t *button) Render(canvas core.Canvas) {
 	size := canvas.Size()
 
 	if t.selected {
-		canvas.Set(0, 0, '', st.Invert())
-		canvas.Set(size.W-1, 0, '', st.Invert())
+		canvas.Set(0, 0, '', st.ToggleInvert())
+		canvas.Set(size.W-1, 0, '', st.ToggleInvert())
 	}
 
 	for i := 0; i < len(t.label); i++ {

--- a/components/input.go
+++ b/components/input.go
@@ -34,7 +34,7 @@ func (n *input) Render(canvas core.Canvas) {
 
 	canvas.Fill(' ', n.style)
 
-	canvas.Set(n.cursor, 0, ' ', n.style.Invert())
+	canvas.Set(n.cursor, 0, ' ', n.style.ToggleInvert())
 
 	size := canvas.Size()
 
@@ -49,7 +49,7 @@ func (n *input) Render(canvas core.Canvas) {
 	for offset, r := range []rune(visibleContent) {
 		st := n.style
 		if offset == clampedCursor {
-			st = st.Invert()
+			st = st.ToggleInvert()
 		}
 		canvas.Set(offset, 0, r, st)
 	}

--- a/components/password.go
+++ b/components/password.go
@@ -34,7 +34,7 @@ func (n *passwordInput) Render(canvas core.Canvas) {
 
 	canvas.Fill(' ', n.style)
 
-	canvas.Set(n.cursor, 0, ' ', n.style.Invert())
+	canvas.Set(n.cursor, 0, ' ', n.style.ToggleInvert())
 
 	size := canvas.Size()
 
@@ -49,7 +49,7 @@ func (n *passwordInput) Render(canvas core.Canvas) {
 	for offset := range []rune(visibleContent) {
 		st := n.style
 		if offset == clampedCursor {
-			st = st.Invert()
+			st = st.ToggleInvert()
 		}
 		canvas.Set(offset, 0, '*', st)
 	}

--- a/components/scrollbar.go
+++ b/components/scrollbar.go
@@ -10,7 +10,7 @@ func drawScrollbar(canvas core.Canvas, index int, size int, max int) {
 
 	for y := 0; y < canvasSize.H; y++ {
 		if y >= barPos && y < barPos+height {
-			canvas.Set(0, y, ' ', core.StyleDefault.Invert())
+			canvas.Set(0, y, ' ', core.StyleDefault.ToggleInvert())
 		} else {
 			canvas.Set(0, y, '│', core.StyleDefault)
 		}

--- a/core/colour.go
+++ b/core/colour.go
@@ -2,8 +2,22 @@ package core
 
 type Colour [3]int32
 
+var ColourFgFaint = NewColour(128, 128, 128)
+
 func NewColour(r, g, b int32) Colour {
 	return Colour([3]int32{r, g, b})
+}
+
+func FaintColour(c Colour) Colour {
+	if !c.IsDefault() {
+		return NewColour(
+			c.Red()/2,
+			c.Green()/2,
+			c.Blue()/2,
+		)
+	}
+
+	return ColourFgFaint
 }
 
 func (c Colour) Red() int32 {
@@ -16,4 +30,8 @@ func (c Colour) Green() int32 {
 
 func (c Colour) Blue() int32 {
 	return c[2]
+}
+
+func (c Colour) IsDefault() bool {
+	return c[0] == 0 && c[1] == 0 && c[2] == 0
 }

--- a/core/colour_test.go
+++ b/core/colour_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestColourFunctions(t *testing.T) {
+func TestNewColour(t *testing.T) {
 
 	inputs := [][3]int32{
 		{0, 0, 0},
@@ -25,6 +25,53 @@ func TestColourFunctions(t *testing.T) {
 			assert.Equal(t, input[0], colour.Red())
 			assert.Equal(t, input[1], colour.Green())
 			assert.Equal(t, input[2], colour.Blue())
+		})
+	}
+}
+
+func TestFaintColour(t *testing.T) {
+	testCases := []struct {
+		input  [3]int32
+		output [3]int32
+	}{
+		{input: [3]int32{0, 0, 0}, output: [3]int32{128, 128, 128}},
+		{input: [3]int32{1, 2, 3}, output: [3]int32{0, 1, 1}},
+		{input: [3]int32{255, 255, 0}, output: [3]int32{127, 127, 0}},
+		{input: [3]int32{0, 255, 0}, output: [3]int32{0, 127, 0}},
+		{input: [3]int32{0, 0, 255}, output: [3]int32{0, 0, 127}},
+		{input: [3]int32{128, 64, 32}, output: [3]int32{64, 32, 16}},
+		{input: [3]int32{255, 255, 255}, output: [3]int32{127, 127, 127}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("%d,%d,%d", testCase.input[0], testCase.input[1], testCase.input[2]), func(t *testing.T) {
+			colour := FaintColour(NewColour(testCase.input[0], testCase.input[1], testCase.input[2]))
+			assert.Equalf(t, testCase.output[0], colour.Red(), "red")
+			assert.Equalf(t, testCase.output[1], colour.Green(), "green")
+			assert.Equalf(t, testCase.output[2], colour.Blue(), "blue")
+		})
+	}
+
+}
+
+func TestColourIsDefault(t *testing.T) {
+	testCases := []struct {
+		input  [3]int32
+		output bool
+	}{
+		{input: [3]int32{0, 0, 0}, output: true},
+		{input: [3]int32{1, 2, 3}, output: false},
+		{input: [3]int32{255, 255, 0}, output: false},
+		{input: [3]int32{0, 255, 0}, output: false},
+		{input: [3]int32{0, 0, 255}, output: false},
+		{input: [3]int32{128, 64, 32}, output: false},
+		{input: [3]int32{255, 255, 255}, output: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("%d,%d,%d", testCase.input[0], testCase.input[1], testCase.input[2]), func(t *testing.T) {
+			result := NewColour(testCase.input[0], testCase.input[1], testCase.input[2]).IsDefault()
+			assert.Equal(t, testCase.output, result)
 		})
 	}
 

--- a/core/core.go
+++ b/core/core.go
@@ -1,0 +1,5 @@
+package core
+
+func init() {
+	SetStyle(StyleInherit)
+}

--- a/core/style.go
+++ b/core/style.go
@@ -5,82 +5,97 @@ import (
 )
 
 type Style struct {
-	inheritFg bool
-	inheritBg bool
-	invert    bool
-	underline bool
-	bold      bool
-	bg        Colour
-	fg        Colour
+	InheritFg bool   `mapstructure:"inherit_fg"`
+	InheritBg bool   `mapstructure:"inherit_bg"`
+	Invert    bool   `mapstructure:"invert"`
+	Underline bool   `mapstructure:"underline"`
+	Bold      bool   `mapstructure:"bold"`
+	Bg        Colour `mapstructure:"bg"`
+	Fg        Colour `mapstructure:"fg"`
 }
 
-var StyleDefault = Style{
-	bg:        Colour([3]int32{0x0d, 0x19, 0x25}),
-	fg:        Colour([3]int32{0xd9, 0xe5, 0xf1}),
-	inheritBg: true,
-}
+var (
+	StyleDefault        Style
+	StyleSelected       Style
+	StyleFaint          Style
+	StyleButton         Style
+	StyleButtonSelected Style
+	StyleInput          Style
+)
 
 var StyleInherit = Style{
-	inheritBg: true,
-	inheritFg: true,
+	InheritBg: true,
+	InheritFg: true,
 }
 
-var StyleSelected = StyleDefault.Invert()
+func SetStyle(style Style) {
+	StyleDefault = style
+	StyleInput = StyleDefault
+	StyleSelected = StyleDefault.ToggleInvert()
+	StyleFaint = StyleDefault.
+		SetInheritForeground(false).
+		SetForeground(FaintColour(StyleDefault.Fg))
+	StyleButton = StyleFaint
+	StyleButtonSelected = style.ToggleInvert().SetBold(true)
+}
 
-var StyleFaint = StyleDefault.SetForeground([3]int32{0x80, 0x80, 0x80})
-
-var StyleButton = StyleFaint
-var StyleButtonSelected = StyleDefault.Invert().Bold(true)
-
-var StyleInput = StyleDefault
-
-func (s Style) Invert() Style {
-	s.invert = !s.invert
+func (s Style) ToggleInvert() Style {
+	s.Invert = !s.Invert
 	return s
 }
 
-func (s Style) Underline(on bool) Style {
-	s.underline = on
+func (s Style) SetUnderline(on bool) Style {
+	s.Underline = on
 	return s
 }
 
-func (s Style) Bold(on bool) Style {
-	s.bold = on
+func (s Style) SetBold(on bool) Style {
+	s.Bold = on
 	return s
 }
 
 func (s Style) RemoveBackground() Style {
-	s.inheritBg = true
+	s.InheritBg = true
 	return s
 }
 
 func (s Style) GetForeground() Colour {
-	return s.fg
+	return s.Fg
 }
 
 func (s Style) GetBackground() Colour {
-	return s.bg
+	return s.Bg
 }
 
 func (s Style) SetForeground(colour Colour) Style {
-	s.fg = colour
+	s.Fg = colour
 	return s
 }
 
 func (s Style) SetBackground(colour Colour) Style {
-	s.bg = colour
+	s.Bg = colour
+	return s
+}
+
+func (s Style) SetInheritForeground(inheritFg bool) Style {
+	s.InheritFg = inheritFg
+	return s
+}
+
+func (s Style) SetInheritBackground(inheritBg bool) Style {
+	s.InheritBg = inheritBg
 	return s
 }
 
 func (s Style) Tcell() tcell.Style {
 	st := tcell.StyleDefault
-	if !s.inheritBg {
+	if !s.InheritBg {
 		bg := s.GetBackground()
 		st = st.Background(tcell.NewRGBColor(bg.Red(), bg.Green(), bg.Blue()))
 	}
-	if !s.inheritFg {
+	if !s.InheritFg {
 		fg := s.GetForeground()
 		st = st.Foreground(tcell.NewRGBColor(fg.Red(), fg.Green(), fg.Blue()))
 	}
-	return st.Reverse(s.invert).Underline(s.underline).Bold(s.bold)
+	return st.Reverse(s.Invert).Underline(s.Underline).Bold(s.Bold)
 }

--- a/window/base_canvas_test.go
+++ b/window/base_canvas_test.go
@@ -10,10 +10,7 @@ import (
 )
 
 func TestBaseCanvasSet(t *testing.T) {
-	screen, err := tcell.NewScreen()
-	if err != nil {
-		t.Fatal(err)
-	}
+	screen := tcell.NewSimulationScreen("")
 	if err := screen.Init(); err != nil {
 		t.Fatal(err)
 	}
@@ -29,10 +26,7 @@ func TestBaseCanvasSet(t *testing.T) {
 }
 
 func TestBaseCanvasSize(t *testing.T) {
-	screen, err := tcell.NewScreen()
-	if err != nil {
-		t.Fatal(err)
-	}
+	screen := tcell.NewSimulationScreen("")
 	if err := screen.Init(); err != nil {
 		t.Fatal(err)
 	}
@@ -48,10 +42,7 @@ func TestBaseCanvasSize(t *testing.T) {
 }
 
 func TestBaseCanvasCutout(t *testing.T) {
-	screen, err := tcell.NewScreen()
-	if err != nil {
-		t.Fatal(err)
-	}
+	screen := tcell.NewSimulationScreen("")
 	if err := screen.Init(); err != nil {
 		t.Fatal(err)
 	}

--- a/window/window_test.go
+++ b/window/window_test.go
@@ -8,10 +8,7 @@ import (
 )
 
 func getTermSize(t *testing.T) (int, int) {
-	screen, err := tcell.NewScreen()
-	if err != nil {
-		t.Fatal(err)
-	}
+	screen := tcell.NewSimulationScreen("")
 	if err := screen.Init(); err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +20,7 @@ func TestWindowSize(t *testing.T) {
 
 	w, h := getTermSize(t)
 
-	win, err := New()
+	win, err := New(WindowOptionSimulation())
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
* Set to default style to inherit terminal settings but allow overwriting it with `core.SetStyle(s core.Style)`
* Automatically calculate the fainted foreground colour instead of using a hardcoded value (when the fg colour is not inherited from the terminal)