### PR TITLE
Fix right/left keys handling in confirm widget

### DIFF
--- a/widgets/confirm.go
+++ b/widgets/confirm.go
@@ -63,11 +63,10 @@ func Confirm(msg string) (bool, error) {
 	win.OnKeypress(func(key *tcell.EventKey) bool {
 		switch key.Key() {
 		case tcell.KeyLeft:
-			no.Deselect()
-			yes.Select()
+			strip.Deselect()
+			strip.Select()
 		case tcell.KeyRight:
-			yes.Deselect()
-			no.Select()
+			strip.Select()
 		case tcell.KeyRune:
 			switch key.Rune() {
 			case 'y', 'Y':


### PR DESCRIPTION
Quick (and dirty?) fix. Forward `Select`/`Deselect` calls to the buttons' parent component when handling right/left key press.

Fixes https://github.com/liamg/flinch/issues/6 